### PR TITLE
Upgrade calico and adjust MTU

### DIFF
--- a/manifests/Makefile
+++ b/manifests/Makefile
@@ -18,7 +18,7 @@ hcloud-csi/manifests.json:
 		go run ../hack/yaml2json.go | \
 		jq -s  > $@
 
-CALICO_VERSION := 3.11
+CALICO_VERSION := 3.13
 calico/manifests.json:
 	mkdir -p $(shell dirname "$@")
 	curl -sL https://docs.projectcalico.org/v$(CALICO_VERSION)/manifests/calico.yaml | \

--- a/manifests/calico/calico.libsonnet
+++ b/manifests/calico/calico.libsonnet
@@ -6,6 +6,13 @@ upstream {
     podsCIDRBlock: '192.168.0.0/17',
   },
 
+  'calico-config'+: {
+    configMap+: {
+      data+: {
+        veth_mtu: '1430',
+      },
+    },
+  },
 
   'calico-node'+: {
     local this = self,

--- a/manifests/calico/manifests.json
+++ b/manifests/calico/manifests.json
@@ -3,7 +3,7 @@
     "apiVersion": "v1",
     "data": {
       "calico_backend": "bird",
-      "cni_network_config": "{\n  \"name\": \"k8s-pod-network\",\n  \"cniVersion\": \"0.3.1\",\n  \"plugins\": [\n    {\n      \"type\": \"calico\",\n      \"log_level\": \"info\",\n      \"datastore_type\": \"kubernetes\",\n      \"nodename\": \"__KUBERNETES_NODE_NAME__\",\n      \"mtu\": __CNI_MTU__,\n      \"ipam\": {\n          \"type\": \"calico-ipam\"\n      },\n      \"policy\": {\n          \"type\": \"k8s\"\n      },\n      \"kubernetes\": {\n          \"kubeconfig\": \"__KUBECONFIG_FILEPATH__\"\n      }\n    },\n    {\n      \"type\": \"portmap\",\n      \"snat\": true,\n      \"capabilities\": {\"portMappings\": true}\n    }\n  ]\n}",
+      "cni_network_config": "{\n  \"name\": \"k8s-pod-network\",\n  \"cniVersion\": \"0.3.1\",\n  \"plugins\": [\n    {\n      \"type\": \"calico\",\n      \"log_level\": \"info\",\n      \"datastore_type\": \"kubernetes\",\n      \"nodename\": \"__KUBERNETES_NODE_NAME__\",\n      \"mtu\": __CNI_MTU__,\n      \"ipam\": {\n          \"type\": \"calico-ipam\"\n      },\n      \"policy\": {\n          \"type\": \"k8s\"\n      },\n      \"kubernetes\": {\n          \"kubeconfig\": \"__KUBECONFIG_FILEPATH__\"\n      }\n    },\n    {\n      \"type\": \"portmap\",\n      \"snat\": true,\n      \"capabilities\": {\"portMappings\": true}\n    },\n    {\n      \"type\": \"bandwidth\",\n      \"capabilities\": {\"bandwidth\": true}\n    }\n  ]\n}",
       "typha_service_name": "none",
       "veth_mtu": "1440"
     },
@@ -17,82 +17,14 @@
     "apiVersion": "apiextensions.k8s.io/v1beta1",
     "kind": "CustomResourceDefinition",
     "metadata": {
-      "name": "felixconfigurations.crd.projectcalico.org"
+      "name": "bgpconfigurations.crd.projectcalico.org"
     },
     "spec": {
       "group": "crd.projectcalico.org",
       "names": {
-        "kind": "FelixConfiguration",
-        "plural": "felixconfigurations",
-        "singular": "felixconfiguration"
-      },
-      "scope": "Cluster",
-      "version": "v1"
-    }
-  },
-  {
-    "apiVersion": "apiextensions.k8s.io/v1beta1",
-    "kind": "CustomResourceDefinition",
-    "metadata": {
-      "name": "ipamblocks.crd.projectcalico.org"
-    },
-    "spec": {
-      "group": "crd.projectcalico.org",
-      "names": {
-        "kind": "IPAMBlock",
-        "plural": "ipamblocks",
-        "singular": "ipamblock"
-      },
-      "scope": "Cluster",
-      "version": "v1"
-    }
-  },
-  {
-    "apiVersion": "apiextensions.k8s.io/v1beta1",
-    "kind": "CustomResourceDefinition",
-    "metadata": {
-      "name": "blockaffinities.crd.projectcalico.org"
-    },
-    "spec": {
-      "group": "crd.projectcalico.org",
-      "names": {
-        "kind": "BlockAffinity",
-        "plural": "blockaffinities",
-        "singular": "blockaffinity"
-      },
-      "scope": "Cluster",
-      "version": "v1"
-    }
-  },
-  {
-    "apiVersion": "apiextensions.k8s.io/v1beta1",
-    "kind": "CustomResourceDefinition",
-    "metadata": {
-      "name": "ipamhandles.crd.projectcalico.org"
-    },
-    "spec": {
-      "group": "crd.projectcalico.org",
-      "names": {
-        "kind": "IPAMHandle",
-        "plural": "ipamhandles",
-        "singular": "ipamhandle"
-      },
-      "scope": "Cluster",
-      "version": "v1"
-    }
-  },
-  {
-    "apiVersion": "apiextensions.k8s.io/v1beta1",
-    "kind": "CustomResourceDefinition",
-    "metadata": {
-      "name": "ipamconfigs.crd.projectcalico.org"
-    },
-    "spec": {
-      "group": "crd.projectcalico.org",
-      "names": {
-        "kind": "IPAMConfig",
-        "plural": "ipamconfigs",
-        "singular": "ipamconfig"
+        "kind": "BGPConfiguration",
+        "plural": "bgpconfigurations",
+        "singular": "bgpconfiguration"
       },
       "scope": "Cluster",
       "version": "v1"
@@ -119,48 +51,14 @@
     "apiVersion": "apiextensions.k8s.io/v1beta1",
     "kind": "CustomResourceDefinition",
     "metadata": {
-      "name": "bgpconfigurations.crd.projectcalico.org"
+      "name": "blockaffinities.crd.projectcalico.org"
     },
     "spec": {
       "group": "crd.projectcalico.org",
       "names": {
-        "kind": "BGPConfiguration",
-        "plural": "bgpconfigurations",
-        "singular": "bgpconfiguration"
-      },
-      "scope": "Cluster",
-      "version": "v1"
-    }
-  },
-  {
-    "apiVersion": "apiextensions.k8s.io/v1beta1",
-    "kind": "CustomResourceDefinition",
-    "metadata": {
-      "name": "ippools.crd.projectcalico.org"
-    },
-    "spec": {
-      "group": "crd.projectcalico.org",
-      "names": {
-        "kind": "IPPool",
-        "plural": "ippools",
-        "singular": "ippool"
-      },
-      "scope": "Cluster",
-      "version": "v1"
-    }
-  },
-  {
-    "apiVersion": "apiextensions.k8s.io/v1beta1",
-    "kind": "CustomResourceDefinition",
-    "metadata": {
-      "name": "hostendpoints.crd.projectcalico.org"
-    },
-    "spec": {
-      "group": "crd.projectcalico.org",
-      "names": {
-        "kind": "HostEndpoint",
-        "plural": "hostendpoints",
-        "singular": "hostendpoint"
+        "kind": "BlockAffinity",
+        "plural": "blockaffinities",
+        "singular": "blockaffinity"
       },
       "scope": "Cluster",
       "version": "v1"
@@ -178,6 +76,23 @@
         "kind": "ClusterInformation",
         "plural": "clusterinformations",
         "singular": "clusterinformation"
+      },
+      "scope": "Cluster",
+      "version": "v1"
+    }
+  },
+  {
+    "apiVersion": "apiextensions.k8s.io/v1beta1",
+    "kind": "CustomResourceDefinition",
+    "metadata": {
+      "name": "felixconfigurations.crd.projectcalico.org"
+    },
+    "spec": {
+      "group": "crd.projectcalico.org",
+      "names": {
+        "kind": "FelixConfiguration",
+        "plural": "felixconfigurations",
+        "singular": "felixconfiguration"
       },
       "scope": "Cluster",
       "version": "v1"
@@ -221,6 +136,91 @@
     "apiVersion": "apiextensions.k8s.io/v1beta1",
     "kind": "CustomResourceDefinition",
     "metadata": {
+      "name": "hostendpoints.crd.projectcalico.org"
+    },
+    "spec": {
+      "group": "crd.projectcalico.org",
+      "names": {
+        "kind": "HostEndpoint",
+        "plural": "hostendpoints",
+        "singular": "hostendpoint"
+      },
+      "scope": "Cluster",
+      "version": "v1"
+    }
+  },
+  {
+    "apiVersion": "apiextensions.k8s.io/v1beta1",
+    "kind": "CustomResourceDefinition",
+    "metadata": {
+      "name": "ipamblocks.crd.projectcalico.org"
+    },
+    "spec": {
+      "group": "crd.projectcalico.org",
+      "names": {
+        "kind": "IPAMBlock",
+        "plural": "ipamblocks",
+        "singular": "ipamblock"
+      },
+      "scope": "Cluster",
+      "version": "v1"
+    }
+  },
+  {
+    "apiVersion": "apiextensions.k8s.io/v1beta1",
+    "kind": "CustomResourceDefinition",
+    "metadata": {
+      "name": "ipamconfigs.crd.projectcalico.org"
+    },
+    "spec": {
+      "group": "crd.projectcalico.org",
+      "names": {
+        "kind": "IPAMConfig",
+        "plural": "ipamconfigs",
+        "singular": "ipamconfig"
+      },
+      "scope": "Cluster",
+      "version": "v1"
+    }
+  },
+  {
+    "apiVersion": "apiextensions.k8s.io/v1beta1",
+    "kind": "CustomResourceDefinition",
+    "metadata": {
+      "name": "ipamhandles.crd.projectcalico.org"
+    },
+    "spec": {
+      "group": "crd.projectcalico.org",
+      "names": {
+        "kind": "IPAMHandle",
+        "plural": "ipamhandles",
+        "singular": "ipamhandle"
+      },
+      "scope": "Cluster",
+      "version": "v1"
+    }
+  },
+  {
+    "apiVersion": "apiextensions.k8s.io/v1beta1",
+    "kind": "CustomResourceDefinition",
+    "metadata": {
+      "name": "ippools.crd.projectcalico.org"
+    },
+    "spec": {
+      "group": "crd.projectcalico.org",
+      "names": {
+        "kind": "IPPool",
+        "plural": "ippools",
+        "singular": "ippool"
+      },
+      "scope": "Cluster",
+      "version": "v1"
+    }
+  },
+  {
+    "apiVersion": "apiextensions.k8s.io/v1beta1",
+    "kind": "CustomResourceDefinition",
+    "metadata": {
       "name": "networkpolicies.crd.projectcalico.org"
     },
     "spec": {
@@ -251,6 +251,7 @@
       "version": "v1"
     }
   },
+  null,
   {
     "apiVersion": "rbac.authorization.k8s.io/v1",
     "kind": "ClusterRole",
@@ -375,6 +376,17 @@
         "verbs": [
           "watch",
           "list",
+          "get"
+        ]
+      },
+      {
+        "apiGroups": [
+          ""
+        ],
+        "resources": [
+          "configmaps"
+        ],
+        "verbs": [
           "get"
         ]
       },
@@ -640,10 +652,6 @@
                   }
                 },
                 {
-                  "name": "CALICO_IPV4POOL_CIDR",
-                  "value": "192.168.0.0/16"
-                },
-                {
                   "name": "CALICO_DISABLE_FILE_LOGGING",
                   "value": "true"
                 },
@@ -664,7 +672,7 @@
                   "value": "true"
                 }
               ],
-              "image": "calico/node:v3.11.2",
+              "image": "calico/node:v3.13.2",
               "livenessProbe": {
                 "exec": {
                   "command": [
@@ -750,7 +758,7 @@
                   }
                 }
               ],
-              "image": "calico/cni:v3.11.2",
+              "image": "calico/cni:v3.13.2",
               "name": "upgrade-ipam",
               "securityContext": {
                 "privileged": true
@@ -806,7 +814,7 @@
                   "value": "false"
                 }
               ],
-              "image": "calico/cni:v3.11.2",
+              "image": "calico/cni:v3.13.2",
               "name": "install-cni",
               "securityContext": {
                 "privileged": true
@@ -823,7 +831,7 @@
               ]
             },
             {
-              "image": "calico/pod2daemon-flexvol:v3.11.2",
+              "image": "calico/pod2daemon-flexvol:v3.13.2",
               "name": "flexvol-driver",
               "securityContext": {
                 "privileged": true
@@ -837,7 +845,7 @@
             }
           ],
           "nodeSelector": {
-            "beta.kubernetes.io/os": "linux"
+            "kubernetes.io/os": "linux"
           },
           "priorityClassName": "system-node-critical",
           "serviceAccountName": "calico-node",
@@ -977,7 +985,7 @@
                   "value": "kubernetes"
                 }
               ],
-              "image": "calico/kube-controllers:v3.11.2",
+              "image": "calico/kube-controllers:v3.13.2",
               "name": "calico-kube-controllers",
               "readinessProbe": {
                 "exec": {
@@ -990,7 +998,7 @@
             }
           ],
           "nodeSelector": {
-            "beta.kubernetes.io/os": "linux"
+            "kubernetes.io/os": "linux"
           },
           "priorityClassName": "system-cluster-critical",
           "serviceAccountName": "calico-kube-controllers",


### PR DESCRIPTION
7c4ef2c (Christian Simon, 5 days ago)
   Lower MTU to match Hcloud's MTU

   HCloud MTU is 1450, with Calico's IP-in-IP we need to set it to 1430
   (This is down by 10 bytes from the default 1440)

8d26679 (Christian Simon, 5 days ago)
   Upgrade calico to 3.13.2